### PR TITLE
merge additional plugin managers

### DIFF
--- a/lua/catppuccin/lib/detect_integrations.lua
+++ b/lua/catppuccin/lib/detect_integrations.lua
@@ -11,31 +11,33 @@ assert(
 	"before using integration_mappings generate it using the script: `./scripts/generate_integration_mappings_table.lua`"
 )
 
-local installed_plugins = nil
+local installed_plugins = {}
 
 if vim.fn.has "nvim-0.12.0" == 1 then
-	installed_plugins = vim.iter(vim.pack.get()):map(function(plugin) return plugin.spec.name end)
+	vim.list_extend(
+		installed_plugins,
+		vim.iter(vim.pack.get()):map(function(plugin) return plugin.spec.name end):totable()
+	)
 end
 
-if pcall(require, "pckr") then installed_plugins = vim.iter(require("pckr.plugin").plugins_by_name) end
+if pcall(require, "pckr") then vim.list_extend(installed_plugins, require("pckr.plugin").plugins_by_name) end
 
-if pcall(require, "lazy") then installed_plugins = vim.iter(require("lazy.core.config").plugins) end
+if pcall(require, "lazy") then vim.list_extend(installed_plugins, require("lazy.core.config").plugins) end
 
-assert(installed_plugins ~= nil, "must be populated by one of supported plugin managers")
-local seen = {}
-installed_plugins
+local seen = vim.iter(installed_plugins)
 	:map(function(plugin_name)
-		if plugin_name:match "mini.*" then
+		if string.sub(plugin_name, 0, 5) == "mini." then
 			return "mini.nvim"
-		else
-			return plugin_name
 		end
+
+		return plugin_name
 	end)
-	:filter(function(plugin_name)
-		if seen[plugin_name] then return false end
-		seen[plugin_name] = true
-		return true
+	:fold({}, function(s, plugin_name)
+		if s[plugin_name] then return s end
+		s[plugin_name] = true
+		return s
 	end)
+
 function M.create_integrations_table()
 	local integrations = {}
 	local ctp_defaults = require("catppuccin").default_options.integrations

--- a/lua/catppuccin/lib/detect_integrations.lua
+++ b/lua/catppuccin/lib/detect_integrations.lua
@@ -11,9 +11,10 @@ assert(
 	"before using integration_mappings generate it using the script: `./scripts/generate_integration_mappings_table.lua`"
 )
 
-local installed_plugins = {}
+local installed_plugins = nil
+
 if vim.fn.has "nvim-0.12.0" == 1 then
-	installed_plugins = vim.iter(vim.pack.get()):map(function(plug) return plug.spec.name end)
+	installed_plugins = vim.iter(vim.pack.get()):map(function(plugin) return plugin.spec.name end)
 end
 
 if pcall(require, "pckr") then installed_plugins = vim.iter(require("pckr.plugin").plugins_by_name) end

--- a/lua/catppuccin/lib/detect_integrations.lua
+++ b/lua/catppuccin/lib/detect_integrations.lua
@@ -11,6 +11,7 @@ assert(
 	"before using integration_mappings generate it using the script: `./scripts/generate_integration_mappings_table.lua`"
 )
 
+local installed_plugins = {}
 if vim.fn.has "nvim-0.12.0" == 1 then
 	installed_plugins = vim.iter(vim.pack.get()):map(function(plug) return plug.spec.name end)
 end

--- a/lua/catppuccin/lib/detect_integrations.lua
+++ b/lua/catppuccin/lib/detect_integrations.lua
@@ -24,7 +24,9 @@ if pcall(require, "pckr") then vim.list_extend(installed_plugins, require("pckr.
 
 if pcall(require, "lazy") then vim.list_extend(installed_plugins, require("lazy.core.config").plugins) end
 
-local seen = vim.iter(installed_plugins)
+local seen = {}
+
+installed_plugins = vim.iter(installed_plugins)
 	:map(function(plugin_name)
 		if string.sub(plugin_name, 0, 5) == "mini." then
 			return "mini.nvim"
@@ -32,17 +34,19 @@ local seen = vim.iter(installed_plugins)
 
 		return plugin_name
 	end)
-	:fold({}, function(s, plugin_name)
-		if s[plugin_name] then return s end
-		s[plugin_name] = true
-		return s
-	end)
+	:filter(function(plugin_name)
+		if seen[plugin_name] then
+			return false
+		end
+		seen[plugin_name] = true
+		return true
+	end):totable()
 
 function M.create_integrations_table()
 	local integrations = {}
 	local ctp_defaults = require("catppuccin").default_options.integrations
 
-	for _, plugin in ipairs(installed_plugins:totable()) do
+	for _, plugin in ipairs(installed_plugins) do
 		if integration_mappings[plugin] ~= nil then
 			local integration = integration_mappings[plugin]
 			if type(ctp_defaults[integration]) == "table" then

--- a/lua/catppuccin/lib/detect_integrations.lua
+++ b/lua/catppuccin/lib/detect_integrations.lua
@@ -11,21 +11,15 @@ assert(
 	"before using integration_mappings generate it using the script: `./scripts/generate_integration_mappings_table.lua`"
 )
 
-local installed_plugins = {}
-
-if pcall(require, "lazy") then
-	for plugin, _ in pairs(require("lazy.core.config").plugins) do
-		-- special case for the "mini" library, if one module is present, mark as if the whole library is installed
-		if plugin:match "mini.*" then
-			if not vim.tbl_contains(installed_plugins, "mini.nvim") then
-				table.insert(installed_plugins, "mini.nvim")
-			end
-		else
-			table.insert(installed_plugins, plugin)
-		end
-	end
+if vim.fn.has "nvim-0.12.0" == 1 then
+	installed_plugins = vim.iter(vim.pack.get()):map(function(plug) return plug.spec.name end)
 end
 
+if pcall(require, "pckr") then installed_plugins = vim.iter(require("pckr.plugin").plugins_by_name) end
+
+if pcall(require, "lazy") then installed_plugins = vim.iter(require("lazy.core.config").plugins) end
+
+assert(installed_plugins ~= nil, "must be populated by one of supported plugin managers")
 function M.create_integrations_table()
 	local integrations = {}
 	local ctp_defaults = require("catppuccin").default_options.integrations

--- a/lua/catppuccin/lib/detect_integrations.lua
+++ b/lua/catppuccin/lib/detect_integrations.lua
@@ -20,11 +20,25 @@ if pcall(require, "pckr") then installed_plugins = vim.iter(require("pckr.plugin
 if pcall(require, "lazy") then installed_plugins = vim.iter(require("lazy.core.config").plugins) end
 
 assert(installed_plugins ~= nil, "must be populated by one of supported plugin managers")
+local seen = {}
+installed_plugins
+	:map(function(plugin_name)
+		if plugin_name:match "mini.*" then
+			return "mini.nvim"
+		else
+			return plugin_name
+		end
+	end)
+	:filter(function(plugin_name)
+		if seen[plugin_name] then return false end
+		seen[plugin_name] = true
+		return true
+	end)
 function M.create_integrations_table()
 	local integrations = {}
 	local ctp_defaults = require("catppuccin").default_options.integrations
 
-	for _, plugin in ipairs(installed_plugins) do
+	for _, plugin in ipairs(installed_plugins:totable()) do
 		if integration_mappings[plugin] ~= nil then
 			local integration = integration_mappings[plugin]
 			if type(ctp_defaults[integration]) == "table" then


### PR DESCRIPTION
- allow multiple plugin managers
- use `string.sub` where patterns aren't needed

before merging this can you explain the use for the `seen` variable?